### PR TITLE
Proper checksum tests

### DIFF
--- a/beautiful_barcode/__init__.py
+++ b/beautiful_barcode/__init__.py
@@ -1,4 +1,3 @@
 from .upc import UPCA  # noqa
 
 __version__ = '1.0.0'
-

--- a/beautiful_barcode/upc.py
+++ b/beautiful_barcode/upc.py
@@ -19,16 +19,21 @@ _UPC_MODULE_COUNT = 95
 
 
 def calc_upc_checksum(upc):
-    assert isinstance(upc, str)
-    assert re.match(r'^[0-9]{12}$', upc)
     return (- sum(
         (3 if pos % 2 == 0 else 1) * num
         for pos, num in enumerate(map(int, upc[:-1])))) % 10
 
 
 class UPCA(Barcode):
-    def __init__(self, upc):
+    def __init__(self, upc: str):
         super().__init__()
+
+        assert isinstance(upc, str)
+        if not re.match(r'^[0-9]{12}$', upc):
+            raise ValueError(f'UPC {upc!r} is not 12 latin digits')
+        upc_checksum = calc_upc_checksum(upc)
+        if upc_checksum != int(upc[-1]):
+            raise ValueError(f'UPC checksum of {upc} should be {upc_checksum}')
 
         self.upc = upc
 

--- a/test/test_upc.py
+++ b/test/test_upc.py
@@ -7,15 +7,21 @@ from beautiful_barcode import UPCA
 class UPCTest(unittest.TestCase):
     def test_upc_modules(self):
         self.assertEqual(
-            UPCA('012345012345').to_modules(),
+            UPCA('012345012341').to_modules(),
             ('101  0001101 0011001 0010011 0111101 0100011 0110001  01010'
-             '     1110010 1100110 1101100 1000010 1011100 1001110  101')
+             '     1110010 1100110 1101100 1000010 1011100 1100110  101')
             .replace(' ', '')
         )
 
         self.assertEqual(
-            UPCA('567890567890').to_modules(),
+            UPCA('567890567896').to_modules(),
             ('101  0110001 0101111 0111011 0110111 0001011 0001101  01010'
-             '     1001110 1010000 1000100 1001000 1110100 1110010  101')
+             '     1001110 1010000 1000100 1001000 1110100 1010000  101')
             .replace(' ', '')
         )
+
+    def test_checksum(self):
+        with self.assertRaisesRegex(ValueError, r'UPC \'12345678901\' is not 12 latin digits'):
+            UPCA('12345678901')
+        with self.assertRaisesRegex(ValueError, r'UPC checksum of 123456789013 should be 2'):
+            UPCA('123456789013')


### PR DESCRIPTION
Check the UPC checksum (= the last digit) and raise a proper ValueError if it does not match.
