### PR TITLE
Default to the Path renderer

### DIFF
--- a/beautiful_barcode/renderers.py
+++ b/beautiful_barcode/renderers.py
@@ -95,7 +95,7 @@ def make_renderer(spec):
 
 
 NAMED_RENDERERS = {
-    'auto': SimpleTextSVGRenderer,  # Subject to change
+    'auto': PathSVGRenderer,  # Subject to change
     'simple': SimpleTextSVGRenderer,
     'inkscape': InkscapeSVGRenderer,
     'path': PathSVGRenderer,


### PR DESCRIPTION
The PathSVGRenderer works everywhere and creates safe files that do not depend on the viewer's fonts.

Hence, it should be the default. (It's linked and described already in the README)
