### PR TITLE
uppercase GTIN class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ $ pip install beautiful_barcode
 # Usage
 
 ```
->>> from beautiful_barcode import gtin
->>> gtin('123456789012').write('output.svg')
+>>> from beautiful_barcode import GTIN
+>>> GTIN('123456789012').write('output.svg')
 ```
 
 Command line:

--- a/beautiful_barcode/__init__.py
+++ b/beautiful_barcode/__init__.py
@@ -1,14 +1,14 @@
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 from .ean import EAN  # noqa
 from .upc import UPCA  # noqa
 
 
-def gtin(value):
-    length = len(value)
+def GTIN(gtin):
+    length = len(gtin)
     if length == 12:
-        return UPCA(value)
+        return UPCA(gtin)
     elif length == 13:
-        return EAN(value)
+        return EAN(gtin)
     else:
         raise ValueError(f'Unsupported GTIN {gtin!r} of length {length}')

--- a/beautiful_barcode/__main__.py
+++ b/beautiful_barcode/__main__.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 
-from . import gtin, renderers
+from . import GTIN, renderers
 
 
 def main():
@@ -15,7 +15,7 @@ def main():
         help='UPC-A or EAN number, for example 123456789012 or 4251192108913')
     args = parser.parse_args()
 
-    barcode = gtin(args.NUMBER)
+    barcode = GTIN(args.NUMBER)
     render_kwargs = {
         'renderer': args.renderer,
     }


### PR DESCRIPTION
`gtin` is often a variable name. Upper-case it.
bump release number, but since 1.1.0 never was officially released it should be fine.
