### PR TITLE
specific exception

### DIFF
--- a/beautiful_barcode/__init__.py
+++ b/beautiful_barcode/__init__.py
@@ -1,6 +1,7 @@
 __version__ = '1.1.3'
 
 from .ean import EAN  # noqa
+from .exceptions import InvalidGTIN
 from .upc import UPCA  # noqa
 
 
@@ -11,4 +12,4 @@ def GTIN(gtin):
     elif length == 13:
         return EAN(gtin)
     else:
-        raise ValueError(f'Unsupported GTIN {gtin!r} of length {length}')
+        raise InvalidGTIN(f'Unsupported GTIN {gtin!r} of length {length}')

--- a/beautiful_barcode/ean.py
+++ b/beautiful_barcode/ean.py
@@ -1,6 +1,7 @@
 import re
 
 from .barcode import Barcode
+from .exceptions import InvalidGTIN
 from .utils import module_coords
 
 
@@ -39,10 +40,10 @@ class EAN(Barcode):
 
         assert isinstance(ean, str)
         if not re.match(r'^[0-9]{13}$', ean):
-            raise ValueError(f'EAN {ean!r} is not 13 latin digits')
+            raise InvalidGTIN(f'EAN {ean!r} is not 13 latin digits')
         checksum = calc_ean_checksum(ean)
         if checksum != int(ean[-1]):
-            raise ValueError(f'EAN checksum of {ean} should be {checksum}')
+            raise InvalidGTIN(f'EAN checksum of {ean} should be {checksum}')
 
         self.ean = ean
 

--- a/beautiful_barcode/exceptions.py
+++ b/beautiful_barcode/exceptions.py
@@ -1,0 +1,2 @@
+class InvalidGTIN(ValueError):
+    pass

--- a/beautiful_barcode/upc.py
+++ b/beautiful_barcode/upc.py
@@ -1,6 +1,7 @@
 import re
 
 from .barcode import Barcode
+from .exceptions import InvalidGTIN
 from .utils import module_coords
 
 
@@ -30,10 +31,10 @@ class UPCA(Barcode):
 
         assert isinstance(upc, str)
         if not re.match(r'^[0-9]{12}$', upc):
-            raise ValueError(f'UPC {upc!r} is not 12 latin digits')
+            raise InvalidGTIN(f'UPC {upc!r} is not 12 latin digits')
         upc_checksum = calc_upc_checksum(upc)
         if upc_checksum != int(upc[-1]):
-            raise ValueError(f'UPC checksum of {upc} should be {upc_checksum}')
+            raise InvalidGTIN(f'UPC checksum of {upc} should be {upc_checksum}')
 
         self.upc = upc
 

--- a/test/test_ean.py
+++ b/test/test_ean.py
@@ -1,7 +1,7 @@
 import unittest
 
 import tutils  # noqa
-from beautiful_barcode import EAN
+from beautiful_barcode import EAN, InvalidGTIN
 from beautiful_barcode.ean import _L_DIGITS, _G_DIGITS, _R_DIGITS
 
 
@@ -39,14 +39,14 @@ class EANTest(unittest.TestCase):
         )
 
     def test_checksum(self):
-        with self.assertRaisesRegex(ValueError, r'EAN \'56789056789\' is not 13 latin digits'):
+        with self.assertRaisesRegex(InvalidGTIN, r'EAN \'56789056789\' is not 13 latin digits'):
             EAN('56789056789')
-        with self.assertRaisesRegex(ValueError, r'EAN \'567890567890\' is not 13 latin digits'):
+        with self.assertRaisesRegex(InvalidGTIN, r'EAN \'567890567890\' is not 13 latin digits'):
             EAN('567890567890')
-        with self.assertRaisesRegex(ValueError, r'EAN checksum of 5678905678967 should be 6'):
+        with self.assertRaisesRegex(InvalidGTIN, r'EAN checksum of 5678905678967 should be 6'):
             EAN('5678905678967')
-        with self.assertRaisesRegex(ValueError, r'EAN checksum of 4251192107550 should be 8'):
+        with self.assertRaisesRegex(InvalidGTIN, r'EAN checksum of 4251192107550 should be 8'):
             EAN('4251192107550')
-        with self.assertRaisesRegex(ValueError, r'EAN checksum of 1222222222222 should be 3'):
+        with self.assertRaisesRegex(InvalidGTIN, r'EAN checksum of 1222222222222 should be 3'):
             EAN('1222222222222')
 

--- a/test/test_upc.py
+++ b/test/test_upc.py
@@ -1,7 +1,7 @@
 import unittest
 
 import tutils  # noqa
-from beautiful_barcode import UPCA
+from beautiful_barcode import InvalidGTIN, UPCA
 
 
 class UPCTest(unittest.TestCase):
@@ -21,7 +21,9 @@ class UPCTest(unittest.TestCase):
         )
 
     def test_checksum(self):
-        with self.assertRaisesRegex(ValueError, r'UPC \'12345678901\' is not 12 latin digits'):
+        with self.assertRaisesRegex(InvalidGTIN, r'UPC \'12345678901\' is not 12 latin digits'):
             UPCA('12345678901')
-        with self.assertRaisesRegex(ValueError, r'UPC checksum of 123456789013 should be 2'):
+        with self.assertRaisesRegex(InvalidGTIN, r'UPC \'12345678901a\' is not 12 latin digits'):
+            UPCA('12345678901a')
+        with self.assertRaisesRegex(InvalidGTIN, r'UPC checksum of 123456789013 should be 2'):
             UPCA('123456789013')


### PR DESCRIPTION
Raise `InvalidGTIN` so users can catch this specific problem rather than handling all `ValueError`s.

